### PR TITLE
Fix some builds and set preview version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,9 +57,6 @@ jobs:
     needs: build
     environment:
       name: NuGet.org
-      url: https://www.nuget.org/packages/SlnUp/
-
-    if: ${{ !contains(needs.build.outputs.package_version, '-') }}
 
     steps:
       - name: Setup NuGet

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET SDK
+      - name: Setup .NET 3.1.x SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+
+      - name: Setup .NET 5.x SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.x
+
+      - name: Setup .NET 6.x SDK
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.x

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -21,7 +21,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET SDK
+      - name: Setup .NET 3.1.x SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+
+      - name: Setup .NET 5.x SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.x
+
+      - name: Setup .NET 6.x SDK
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.x

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ${{ matrix.platform }}-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1

--- a/src/CentralBuildOutput/version.json
+++ b/src/CentralBuildOutput/version.json
@@ -1,4 +1,4 @@
 {
   "inherit": true,
-  "version": "0.1"
+  "version": "0.1.0-beta.{height}"
 }


### PR DESCRIPTION
Fixing a few build issues and setting the CentralBuildOutput package to a preview version number. Builds are still broken on Linux and macOS due to test issues.