### PR TITLE
Fix tests on Linux and macOS

### DIFF
--- a/packages.props
+++ b/packages.props
@@ -16,6 +16,7 @@
                       IncludeAssets="runtime; build; native; contentfiles; analyzers"
                       PrivateAssets="all" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                           Version="17.1.0" />
+    <PackageReference Update="Mono.Posix.NETStandard"                           Version="1.0.0" />
     <PackageReference Update="MSBuild.ProjectCreation"                          Version="8.0.0-preview" />
     <PackageReference Update="Shouldly"                                         Version="4.0.3" />
     <PackageReference Update="xunit"                                            Version="2.4.1" />

--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Mono.Posix.NETStandard" />
     <PackageReference Include="MSBuild.ProjectCreation" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />

--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -32,9 +32,6 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
 
         // Assert
         Properties properties = Properties.Load(project);
-        this.TestOutput.WriteLine($"ProjectOutput: {this.ProjectOutput}");
-        this.TestOutput.WriteLine($"ProjectOutput exists: {Directory.Exists(this.ProjectOutput)}");
-        this.TestOutput.WriteLine(properties.ToString());
 
         CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
         cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/AppPackages/");

--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -32,6 +32,9 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
 
         // Assert
         Properties properties = Properties.Load(project);
+        this.TestOutput.WriteLine($"ProjectOutput: {this.ProjectOutput}");
+        this.TestOutput.WriteLine($"ProjectOutput exists: {Directory.Exists(this.ProjectOutput)}");
+        this.TestOutput.WriteLine(properties.ToString());
 
         CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
         cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/AppPackages/");

--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -59,7 +59,11 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
         CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
         msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
         msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/");
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.0\\");
+
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.0/");
 
         CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
         msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/");
@@ -186,7 +190,11 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
         CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
         msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
         msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/");
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/netstandard2.0\\");
+
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Debug/AnyCPU/netstandard2.0/");
 
         CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
         msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/");
@@ -234,7 +242,11 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
         CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
         msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
         msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/MyClassLibrary/");
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/MyClassLibrary/netstandard2.0\\");
+
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Debug/AnyCPU/MyClassLibrary/netstandard2.0/");
 
         CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
         msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/MyClassLibrary/");

--- a/src/CentralBuildOutput.Tests/Extensions/StringExtensions.cs
+++ b/src/CentralBuildOutput.Tests/Extensions/StringExtensions.cs
@@ -17,4 +17,7 @@ internal static class StringExtensions
 
         return result;
     }
+
+    public static string ToPosixPath(this string path)
+        => path.Replace('\\', '/');
 }

--- a/src/CentralBuildOutput.Tests/OperatingSystem.cs
+++ b/src/CentralBuildOutput.Tests/OperatingSystem.cs
@@ -1,0 +1,29 @@
+namespace Treasure.Build.CentralBuildOutput.Tests;
+
+#if NETCOREAPP3_1
+using System.Runtime.InteropServices;
+#endif
+
+internal static class OperatingSystem
+{
+    public static bool IsLinux() =>
+#if NET5_0_OR_GREATER
+        System.OperatingSystem.IsLinux();
+#else
+        RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+#endif
+
+    public static bool IsMacOS() =>
+#if NET5_0_OR_GREATER
+        System.OperatingSystem.IsMacOS();
+#else
+        RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+#endif
+
+    public static bool IsWindows() =>
+#if NET5_0_OR_GREATER
+        System.OperatingSystem.IsWindows();
+#else
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+}

--- a/src/CentralBuildOutput.Tests/TestProjectOutput.cs
+++ b/src/CentralBuildOutput.Tests/TestProjectOutput.cs
@@ -55,4 +55,6 @@ internal class TestProjectOutput : IDisposable
         Environment.CurrentDirectory = outputPath;
         return new TestProjectOutput(outputPath);
     }
+
+    public override string ToString() => this.OutputPath;
 }


### PR DESCRIPTION
  - There is one case where there is a platform specific path separator that slips in that I don't have control over. This change adjusts the path in the tests for that particular case.
  - The macOS build agents appear to use a symlink for the temp path, so we had to add a helper library to help resolve the path so that our tests can compare apples to apples.